### PR TITLE
Fixes close </li> tag after specification

### DIFF
--- a/_includes/header.html
+++ b/_includes/header.html
@@ -26,7 +26,7 @@
 			</a>
 			<ul class="dropdown-menu" role="menu">
 				<li><a href="/doc#manuals">Man Pages</a></li>
-				<li><a href="/doc#specs">Specifications</a><li>
+				<li><a href="/doc#specs">Specifications</a></li>
 				<li><a href="/doc#pubs">Publications</a></li>
 			</ul>
 		</li>


### PR DESCRIPTION
Was causing a phantom list item to appear in the list in some browsers (e.g. lynx).
