### PR TITLE
allow download button on homepage to wrap text

### DIFF
--- a/css/sitewide.css
+++ b/css/sitewide.css
@@ -24,3 +24,7 @@ body {
 	font-size: 80%;
 	color: gray;
 }
+
+.home-boxes .well .btn-lg {
+	white-space:normal;
+}


### PR DESCRIPTION
stops button from overflowing outside the box


![before](https://user-images.githubusercontent.com/524282/31045628-f5d551ba-a5df-11e7-8ad5-e734acbfe6f4.jpg)

![after](https://user-images.githubusercontent.com/524282/31045630-ff37d016-a5df-11e7-8d23-cffd9018e774.jpg)
