### PR TITLE
Suggesting biostars as support forum

### DIFF
--- a/index.html
+++ b/index.html
@@ -62,6 +62,7 @@ layout: default
 			<h3><a href="{{ "/support" | relative_url }}"><i class="glyphicon glyphicon-question-sign"></i> Support</a></h3>
 			<ul>
 				<li><a href="{{ "/support#lists" | relative_url }}">Mailing Lists</a></li>
+				<li><a href="https://www.biostars.org/p/new/post/?tag_val=samtools">Post questions and bug reports on Biostars</a></li>
 				<li><a href="https://github.com/samtools/htslib/issues">HTSlib issues</a></li>
 				<li><a href="https://github.com/samtools/bcftools/issues">BCFtools issues</a></li>
 				<li><a href="https://github.com/samtools/samtools/issues">Samtools issues</a></li>


### PR DESCRIPTION
This PR is meant as the start of a discussion, in which we suggest to redirect users to biostars (https://www.biostars.org/) for questions and PEBCAK bugs, with we = "the biostars moderators and daily contributors". We can take care of most, if not all, questions, and make sure that genuine bugs get reported properly on GitHub. Related twitter thread: https://twitter.com/jomarnz/status/1070614980435853313

The link I tentatively added in the PR redirects to a new post with the `samtools` tag, although it would solve lots of problems if users first use google.

Tagging a few fellow mods: @dpryan79, @lindenb, @RamRS, @genomax, @kevinblighe, @alexpreynolds, @finswimmer, @jrjhealey, @ATpoint, @zx8754 (list not meant to be complete)