### PR TITLE
Updated zlib and cram benchmark pages

### DIFF
--- a/benchmarks/CRAM.md
+++ b/benchmarks/CRAM.md
@@ -7,9 +7,41 @@ highlighting: yes
 CRAM benchmarking
 =================
 
-Benchmarks are using the faster CRAM codecs; primarily deflate and
-rANS.  For comparison we also include "Io_lib"'s Scramble tool for
-bzip2 and lzma CRAM and the Deez tool on one data set.
+(Updated Sep 2019)
+
+<!-- Tested on my gen1c (Intel(R) Xeon(R) CPU E5-2660 0 @ 2.20GHz)
+
+R/W:  perf stat ./test/test_view -@8 -C -o opt... in.bam -p out.cram
+READ: perf stat ./test/test_view -@8 -B out.cram
+-->
+
+Benchmarks of CRAM 2.1 and 3.0 are using the faster CRAM codecs;
+primarily deflate and rANS.
+
+Also included is the performance of the proposed CRAM v3.1 standard.
+This is not yet a ratified GA4GH standard, but these figures give
+indicative results.
+
+The options listed below also include the new proposed compression
+profiles (fast, normal (default), small and archive) that ease the
+trade-off between speed vs size vs random access.  The profiles are
+synonyms for a collection of existing options.  At the time of
+writing, these profiles are:
+
+{:.table}
+Profile          | CRAM versions | options
+---------------- | ------------- | -------
+fast             | 3.0, 3.1      | seqs_per_slice=1000,  level=1
+normal (default) | 3.0, 3.1      | seqs_per_slice=10000
+small            | 3.0           | seqs_per_slice=25000, level=6,use_bzip2
+small            | 3.1           | seqs_per_slice=25000, level=6,use_bzip2,use_fqz
+archive          | 3.0           | seqs_per_slice=100000,level=7,use_bzip2
+archive          | 3.1           | seqs_per_slice=100000,level=7,use_bzip2,use_fqz,use_arith
+
+To demonstrate the absolute smallest size we use add option "use_lzma"
+to the archive profile tests.  This adds considerable encode cost, but
+minimal decode.
+
 
 Coordinate sorted human data
 ----------------------------
@@ -18,20 +50,33 @@ This test set is chr1 of NA12878_S1, downloaded from
 <http://www.ebi.ac.uk/ena/data/view/ERP002490>
 
 Conversion from BAM to <format> is achieved via htslib test_view -b or
--C.  Decoding times are computed using test_view -B (benchmarking
-mode) with performs input, uncompression and decoding only.  Encoding
+-C using 8 threads on a multi-core Intel Xeon E5-2660 system.
+Decoding times are computed using test_view -B (benchmarking mode)
+with performs input, uncompression and decoding only.  Encoding
 time includes decoding of the input BAM, so subtract the BAM decoding
 time to get encode-only, although the difference is only minor.
 
-All times are reported as wall-clock, although typically these
-algorithms are CPU bound so the cpu time is comparable.
+All times are reported as wall-clock, although some I/O time will
+impact this test as the file is large, particularly decode times.
+In this first test we also show both vanilla Zlib and Libdeflate
+implementations of the gzip standard.
+
 
 {:.table}
-Format   |       Size | Encoding(s) | Decoding(s)
--------- | ---------: | ----------: | ----------:
-BAM      | 8164228924 |        1216 |         111
-CRAM v2  | 5716980996 |        1247 |         182
-CRAM v3  | 4922879082 |         574 |         190
+Format               | Options          |     Size(Mb) | Encoding(s) | Decoding(s)
+-------------------- | ---------------- | -----------: | ----------: | ----------:
+BAM (zlib)           |                  |       121710 |        3101 |         438
+BAM (libdeflate)     |                  |       122405 |        2192 |         357
+-------------------- | ---------------- | -----------: | ----------: | ----------:
+CRAM v2.1            |                  |        78259 |        2121 |         407
+-------------------- | ---------------- | -----------: | ----------: | ----------:
+CRAM v3.0            |                  |        66494 |        1094 |         407
+CRAM v3.0            | small            |        64682 |        2122 |         573
+CRAM v3.0            | archive,use_lzma |        63629 |        6654 |         394
+-------------------- | ---------------- | -----------: | ----------: | ----------:
+CRAM v3.1 (proposed) |                  |        62150 |        1324 |         417
+CRAM v3.1 (proposed) | small            |        56204 |        2465 |        1405
+CRAM v3.1 (proposed) | archive,use_lzma |        54237 |        3048 |        1395
 
 E.Coli: sorted, unsorted, with and without references
 -----------------------------------------------------
@@ -39,104 +84,175 @@ E.Coli: sorted, unsorted, with and without references
 To compare CRAM efficiency in a variety of circumstances we chose a
 smaller dataset to more completely explore the parameter space.
 MiSeq_Ecoli_DH10B_110721_PF.bam is the smallest example data taken
-from the Deez paper, so we also include Deez here for comparison.
+from the Deez paper, so we also include Deez itself here for
+comparison too.
+
+The BAM/SAM.gz implementation here uses libdeflate.  Again we use 8
+threads, but note deez was only able to use around 2.
 
 ### Position sorted
 
 {:.table}
-Format       |       Size | Encoding(s) | Decoding(s) | Notes
------------- | ---------: | ----------: | ----------: | :--------------
-SAM          | 5579036306 |          46 |         -   |
-BAM          | 1412001095 |         209 |       17.7  |
-CRAM v2      | 1053744556 |         183 |       26.9  |
-CRAM v3      |  869500447 |          75 |       30.8  |
-CRAM v3+bz2  |  850165878 |         124 |       45.4  | Via Scramble -j
-Deez         |  870040062 |         208 |      165.0  | Via deez
+Format       | Options          |   Size(Mb) | Encoding(s) | Decoding(s)
+------------ | ---------------- | ---------: | ----------: | ----------:
+BAM          |                  |       1420 |        20.4 |        1.8
+SAM.gz       |                  |       1387 |        22.4 |        2.9
+------------ | ---------------- | ---------: | ----------: | ----------:
+CRAM v2.1    |                  |       1048 |        24.6 |        3.5
+------------ | ---------------- | ---------: | ----------: | ----------:
+CRAM v3.0    |                  |        868 |        10.6 |        3.8
+CRAM v3.0    | small            |        844 |        23.6 |        4.8
+CRAM v3.0    | archive,use_lzma |        838 |        94.9 |        4.5
+------------ | ---------------- | ---------: | ----------: | ----------:
+CRAM v3.1    |                  |        830 |        13.2 |        4.2
+CRAM v3.1    | small            |        771 |        35.4 |       17.3
+CRAM v3.1    | archive,use_lzma |        747 |        81.7 |       16.9
+------------ | ---------------- | ---------: | ----------: | ----------:
+Deez         |                  |        842 |       134.6 |       62.8
 
-Extra decoding time for CRAM v3 is largely explained by the additional
-CRC checksums.
+With light-weight level 1 compression and uncompressed level 0 files
+we see CRAM 3 being slower for uncompressed data than CRAM 2.  This is
+due to the additional CRC integrity checks.
 
-The effect of varying compression levels:
-
-{:.table}
-Format  | Level     |        Size | Encoding(s)
-------- | --------- | ----------: | ----------:
-BAM     | 9         |  1399448787 |         403
-BAM     | (default) |  1412001095 |         209
-BAM     | 1         |  1616365585 |          88
-BAM     | u         |  4310414959 |          45
-CRAMv3  | 9         |   862152172 |         193
-CRAMv3  | (default) |   869500447 |          75
-CRAMv3  | 3         |   881163788 |          68
-CRAMv3  | 1         |   886716515 |          69
-CRAMv3  | u         |  2631665078 |          45
-
-Compression level "u" is uncompressed.  Note there is almost no
-difference in speed between CRAM level 1 and the default level.  Maybe
-we need to make -1 more aggressively fast at the expense of ratio.
-
-Also note that BAM -1 is slower to encode than CRAMv3 at default
-levels, although it will be faster to decode.  That makes me wonder
-about how we should deal with temporary files. (Ideally with neither
-BAM nor CRAM compression, but LZ4 or Snappy.)
-
-### Name sorted
+Note the slower time for BAM level 0 than level 1 is purely down to
+increased disk I/O costs; CPU times double for level 1.  Why SAM does
+not pay this penalty is unknown, but it is likely this picture would
+change given a large enough file.
 
 {:.table}
-Format  | Size       | Encoding(s)
-------- | ---------: | ----------:
-BAM     | 2005274489 | 284
-CRAMv2  | 1046736335 | 206
-CRAMv3  |  848319136 |  99
+Format    | Options |   Size(Mb) | Encoding(s) | Decoding(s)
+--------- | ------- | ---------: | ----------: | ----------:
+SAM.gz    | level=1 |       1830 |       22.7  |        3.2
+BAM       | level=1 |       1531 |       17.8  |        1.9
+CRAM v2.1 | level=1 |       1126 |       12.2  |        3.5
+CRAM v3.0 | level=1 |        889 |        9.5  |        3.6
+CRAM v3.1 | level=1 |        858 |       10.3  |        3.7
+--------- | ------- | ---------: | ----------: | ----------:
+SAM       | level=0 |       4463 |        7.8  |        1.5
+BAM       | level=0 |       4310 |       19.6  |        2.1
+CRAM v2.1 | level=0 |       2632 |       10.1  |        4.1
+CRAM v3.0 | level=0 |       2632 |       11.4  |        4.9
+CRAM v3.1 | level=0 |       2632 |       10.9  |        4.8
 
+#### Embeded reference & referenceless encoding (position sorted alignments)
 
-### Embedding & Reference-less encoding
+By default aligned CRAM uses an external reference file.  Portions of
+that reference can be embedded within each slice to remove this
+external file dependency.  On deep data this has minimal impact as the
+reference is small in comparison to the alignments.
 
-Embedded reference - no external file dependencies:
-
-{:.table}
-Format  | Size       |  Encoding(s)
-------- | ---------: | ----------:
-CRAM v2 | 1055144162 | 187
-CRAM v3 |  870779925 |  78
-
-Note that this is almost the same as the default mode of using an
-external reference as the sequence depth is high.
-
-
-Non-reference encoding - all sequence bases are stored verbatim:
-
-{:.table}
-Format  | Size       | Encoding(s)
-------- | ---------: | ----------:
-CRAM v2 | 1140863900 | 387
-CRAM v3 |  941857968 | 100
-
-The significant speed difference between version 2.1 and 3.0 is due to
-improved ways of storing multi-base differences instead of requiring
-one CRAM feature for each base call.
-
-
-Unmapped data
--------------
-
-Human gut sample SAMEA728920 from http://www.ebi.ac.uk/ena/data/view/ERA000116
-This is unmapped data, converted from FASTQ to SAM via biobambam.
-
+CRAM can also do non reference-based compression, storing the sequence
+as-is (like BAM).  This leads to larger files.
 
 {:.table}
-Format       | Size        | Encoding(s)  | Decoding(s) | Notes
------------- | ---------:  | ----------:  | ----------: | --------------------------------
-SAM          | 1443985040  |  15	  |     -       | I/O bound
-FASTQ.gz     |  491867991  | 126	  |    12.7	|
-BAM          |  428540917  |  64	  |     5.5     |
-CRAM v2      |  335644015  |  36	  |     9.8     |
-CRAM v3      |  308745955  |  24	  |     9.3     |
-CRAM v3+bz2  |  289888505  |  32 	  |     -       | Via Scramble -j
-CRAM v3+lzma |  282989638  | 105 	  |     -       | Via Scramble -Z
-CRAM v3 MAX  |  281666960  | 166 	  |     -       | Via Scramble -9 -jZ (bzip2, lzma)
+Format    | Options   |   Size(Mb) | Encoding(s) | Decoding(s)
+--------- | --------- | ---------: | ----------: | ----------:
+CRAM v2.1 |           |       1048 |        24.6 |        3.5
+CRAM v2.1 | embed_ref |       1049 |        25.2 |        3.8
+CRAM v2.1 | no_ref    |       1089 |        53.7 |       13.9
+--------- | --------- | ---------: | ----------: | ----------:
+CRAM v3.0 |           |        868 |        10.6 |        3.8
+CRAM v3.0 | embed_ref |        869 |        10.6 |        3.7
+CRAM v3.0 | no_ref    |        905 |        13.4 |        3.8
+--------- | --------- | ---------: | ----------: | ----------:
+CRAM v3.1 |           |        830 |        13.2 |        4.2
+CRAM v3.1 | embed_ref |        831 |        13.4 |        4.0
+CRAM v3.1 | no_ref    |        866 |        15.9 |        4.6
 
-Scramble was used to test bzip2, lzma and both combined along with
-compression level 9 for maximum shrinkage, although since v1.4 Htslib
-also supports these methods.
+The significant speed difference of no_ref between version 2.1 and 3.0
+is due to improved ways of storing multi-base differences instead of
+requiring one CRAM feature for each base call.
 
+### Name sorted alignments
+
+This is the same file above, with aligned sequencing data, but sorted
+into name order using "samtools sort -n".  BAM is significantly larger
+as the sequences are no longer in sorted order, harming gzip, but CRAM
+does not change size considerably.  This is due to the use of
+reference based compression.  With referenceless compression CRAM will
+grow in size, similar to BAM, as is visible with the "no_ref" option.
+Although "no_ref" it makes minimal difference here, with a very large
+reference it may be preferable to use this on name sorted data to
+reduce memory usage.
+
+{:.table}
+Format       | Options          |   Size(Mb) | Encoding(s) | Decoding(s)
+------------ | ---------------- | ---------: | ----------: | ----------:
+BAM          |                  |       2016 |        26.2 |        2.3
+SAM.gz       |                  |       2005 |        30.8 |        3.4
+------------ | ---------------- | ---------: | ----------: | ----------:
+CRAM v2.1    |                  |       1034 |        26.3 |        5.1
+------------ | ---------------- | ---------: | ----------: | ----------:
+CRAM v3.0    | no_ref           |       1327 |        12.7 |        4.0
+CRAM v3.0    |                  |        846 |        12.5 |        4.7
+CRAM v3.0    | small            |        832 |        22.9 |        4.4
+CRAM v3.0    | archive,use_lzma |        818 |        84.7 |        4.8
+------------ | ---------------- | ---------: | ----------: | ----------:
+CRAM v3.1    | no_ref           |       1302 |        15.5 |        4.2
+CRAM v3.1    |                  |        825 |        14.6 |        5.9
+CRAM v3.1    | small            |        768 |        37.4 |       18.1
+CRAM v3.1    | archive,use_lzma |        741 |        98.3 |       17.5
+ 
+ 
+### Unmapped (name order)
+
+This is the name sorted data above, but with alignments and all
+auxiliary tags stripped out.  This was achieved by converting back to
+FASTQ via "samtools fastq" and from there back to unaligned BAM.  As
+expected the CRAMs are broadly similar in size to the no_ref mapped
+name sorted files.
+
+{:.table}
+Format       | Options          |   Size(Mb) | Encoding(s) | Decoding(s)
+------------ | ---------------- | ---------: | ----------: | ----------:
+FASTQ.pigz   |                  |       1681 |        58.0 |       21.4
+FASTQ.bgzf   |                  |       1710 |        30.0 |        7.9
+BAM          |                  |       1686 |        21.7 |        2.0
+SAM.gz       |                  |       1722 |        28.3 |        2.6
+------------ | ---------------- | ---------: | ----------: | ----------:
+CRAM v2.1    |                  |       1476 |        28.3 |        3.6
+------------ | ---------------- | ---------: | ----------: | ----------:
+CRAM v3.0    |                  |       1236 |        12.0 |        3.7
+CRAM v3.0    | small            |       1231 |        19.5 |        3.5
+CRAM v3.0    | archive,use_lzma |       1041 |       378.5 |        5.2
+------------ | ---------------- | ---------: | ----------: | ----------:
+CRAM v3.1    |                  |       1208 |        14.6 |        5.9
+CRAM v3.1    | small            |       1139 |        73.0 |       16.8
+CRAM v3.1    | archive,use_lzma |        967 |       423.3 |       18.2
+ 
+Note the fastq was compressed with pigz and bgzip both using 8
+threads.  Pigz is smaller, but bgzip's use of libdeflate greatly
+improves the speed.  Both are significantly behind unaligned CRAM
+though so our recommendation is against storing data in native FASTQ
+format.
+
+### Unmapped (Minhash order)
+
+As above, but passed through the experimental "samtools sort -M"
+command first.  This clusters reads by a hash of their sequence,
+having the effect of grouping similar looking data together which
+helps LZ compression algorithms.  Note the data is still unaligned.
+It is a quick alternative to (a better) full genome assembly.  With 8
+threads this sort process took 21 seconds real time, 170 seconds CPU,
+although expect this to be less performant on a very large file as
+would spill temporary files to disk and require a large merge sort.
+
+Note some aligners will need these files sorting (or collating) back
+to name order prior to converting back to FASTQ.
+
+{:.table}
+Format       | Options          |   Size(Mb) | Encoding(s) | Decoding(s)
+------------ | ---------------- | ---------: | ----------: | ----------:
+BAM          |                  |       1207 |        17.0 |        1.5
+------------ | ---------------- | ---------: | ----------: | ----------:
+CRAM v3.0    |                  |        871 |        13.3 |        3.6
+CRAM v3.0    | archive,use_lzma |        831 |       125.8 |        4.9
+------------ | ---------------- | ---------: | ----------: | ----------:
+CRAM v3.1    |                  |        842 |        16.3 |        3.6
+CRAM v3.1    | archive,use_lzma |        748 |       163.5 |       16.0
+
+The effect of "sort -M" on a small deeply sequenced genome is
+profound, giving file sizes comparable to the aligned position sorted
+data and around half the size of the name sorted compressed FASTQ
+file.  Expect this effect to be less pronounced on shallow data sets
+or much larger genomes.

--- a/benchmarks/zlib.md
+++ b/benchmarks/zlib.md
@@ -7,33 +7,38 @@ highlighting: yes
 A comparison of Zlib implementations
 ------------------------------------
 
-Samtools has been minimally tested against both the Intel-optimised and
-CloudFlare-optimised zlibs and shown to work.
+(Updated Sep 2019)
+
+<!-- Tested on my deskpro (Intel(R) Core(TM) i5-4570 CPU @ 3.20GHz)
+using ~/scratch/data/9827_2#49.bam:
+
+READ: perf stat ./test/test_view -B ~/scratch/data/9827_2#49.bam
+R/W:  perf stat ./test/test_view -@4 -b ~/scratch/data/9827_2#49.bam |wc -c
+-->
+
+Htslib / Samtools have been tested against the vanilla Zlib (1.2.11)
+and the the Intel-optimised and CloudFlare-optimised zlibs and shown
+to work.  Htslib also supports, indeed recommends, using libdeflate.
+The benchmarks below indicate why this is recommended.
 
 They can be downloaded from:
 
-* <https://github.com/jtkukunas/zlib>     # Intel
-* <https://github.com/cloudflare/zlib>    # CloudFlare
-
+* <https://github.com/jtkukunas/zlib>      # Intel
+* <https://github.com/cloudflare/zlib>     # CloudFlare
+* <https://github.com/ebiggers/libdeflate> # Libdeflate
 
 External benchmarks comparing the various zlibs (on non-BAM data) are
 available at:
 
 * <https://www.snellman.net/blog/archive/2014-08-04-comparison-of-intel-and-cloudflare-zlib-patches.html>
 
-It is recommended that you perform your own rigorous tests for an
-entire pipeline if you wish to switch to one of the optimised zlib
-implementations, but we present some basic read and read/write tests
-of our own.
+Previously we also tested Intel's igzip library on an older system.
+Like libdeflate this has a different and incompatible API to standard
+Zlib.  Benchmarks for this are estimated by applying a scaling
+(reduction) factor to the old benchmarks based on observed speedup for
+the other libraries.
 
-In addition to these two full Zlib compatible implementations there is
-an Intel igzip library.  This has a different and incompatible API,
-but offers a better tradeoff between size and time than either of
-these libraries.  It needs more work to make it seemlessly fit in to
-Htslib and Samtools, but a branch containing this is benchmarked to
-demonstrate the gains and losses.
-
-### Reading (flagstats)
+### Reading (htslib's test_view -B in.bam)
 
 (1 thread, elapsed ~= cpu time)
 
@@ -41,328 +46,55 @@ demonstrate the gains and losses.
 Zlib Implementation | CPU Time
 ------------------- | :------:
 Original            | 1m 17s
-Intel               | 1m 17s
-CloudFlare          | 1m 17s
+Intel               | 1m 15s
+CloudFlare          | 1m  4s
+Libdeflate          | 0m 43s
 
-### Re-writing (BAM->BAM)
+### Re-writing (BAM->BAM; test_view -b -@4 in.bam | wc -c)
 
 (4 threads, fastest elapsed/CPU, size)
 
 {:.table}
 Zlib Implementation | Level | Elapsed Time  | CPU Time  |       Size
 ------------------- | :---: | :-----------: | --------: | :--------:
-Original            |     6 | 4m 31s        | 12m 50s   | 6499959405
-Intel               |     6 | 3m 49s        |  9m 57s   | 6580893700
-CloudFlare          |     6 | 3m 24s        |  8m 13s   | 6445044187
+Original            |     6 | 3m 12s        | 11m  6s   | 6499959405
+Intel               |     6 | 2m 11s        |  8m 26s   | 6580893700
+CloudFlare          |     6 | 1m 45s        |  6m 38s   | 6445044187
+Libdeflate	    |     6 | 1m 20s        |  4m 57s   | 6526400042
 
 At minimum compression level:
 
 {:.table}
 Zlib Implementation | Level | Elapsed Time  | CPU Time  |       Size
 ------------------- | :---: | :-----------: | --------: | :--------:
-Original            |     1 | 3m 00s        |  6m 42s   | 7042519949
-Intel               |     1 | 2m 24s        |  4m 15s   | 9019497823
-CloudFlare          |     1 | 2m 53s        |  6m 12s   | 6816769584
-igzip               |     1 | 2m 09s        |  3m 26s   | 7324800394
+Original            |     1 | 1m 31s        |  5m 43s   | 7042519949
+Intel               |     1 | 0m 55s        |  3m 21s   | 9019497823
+CloudFlare          |     1 | 1m 14s        |  4m 40s   | 6816769584
+Libdeflate          |     1 | 0m 58s        |  3m 26s   | 6863351382
+igzip (est.)        |     1 | 0m 50s        |  2m 39s   | 7324800394
 
 
 ### Summary
 
-
-CloudFlare zlib is faster and smaller than the default implementation
-at both standard compression level and also level -1.
-
-The Intel zlib specialises in fastest compression at level -1, albeit
-at a weaker compression ratio.
-
-Both can be used with LD_PRELOAD or LD_LIBRARY_PATH without needing to
-recompile samtools/htslib. (Or samtools could be built linking against
-one of these libraries and adding a -rpath, but that needs manual
-modification of the Makefile.)
-
-The igzip specialised BAM compression code runs fastest for zlib-1
-equivalent while giving an acceptable compression ratio, but code
-integration is currently not simple.  Arguably using a different
-format entirely, such as LZ4, would be preferable for temporary
-intermediate files. (Not benchmarked here.)
-
-
-Full reading benchmarks
------------------------
-
-### Original ZLib
-
-{% highlight sh %}
-$ time ./samtools flagstat ~/scratch/data/9827_2#49.bam
-56463236 + 0 in total (QC-passed reads + QC-failed reads)
-0 + 0 secondary
-0 + 0 supplementary
-269248 + 0 duplicates
-55357963 + 0 mapped (98.04% : N/A)
-56463236 + 0 paired in sequencing
-28231618 + 0 read1
-28231618 + 0 read2
-54363468 + 0 properly paired (96.28% : N/A)
-55062652 + 0 with itself and mate mapped
-295311 + 0 singletons (0.52% : N/A)
-360264 + 0 with mate mapped to a different chr
-300699 + 0 with mate mapped to a different chr (mapQ>=5)
-
-real    1m16.934s
-user    1m15.520s
-sys     0m1.300s
-
-$ time ./samtools flagstat ~/scratch/data/9827_2#49.bam
-56463236 + 0 in total (QC-passed reads + QC-failed reads)
-0 + 0 secondary
-0 + 0 supplementary
-269248 + 0 duplicates
-55357963 + 0 mapped (98.04% : N/A)
-56463236 + 0 paired in sequencing
-28231618 + 0 read1
-28231618 + 0 read2
-54363468 + 0 properly paired (96.28% : N/A)
-55062652 + 0 with itself and mate mapped
-295311 + 0 singletons (0.52% : N/A)
-360264 + 0 with mate mapped to a different chr
-300699 + 0 with mate mapped to a different chr (mapQ>=5)
-
-real    1m16.891s
-user    1m15.820s
-sys     0m0.950s
-{% endhighlight %}
-
-### Intel ZLib
-
-{% highlight sh %}
-$ time LD_PRELOAD=/tmp/zlib.intel/libz.so ./samtools flagstat ~/scratch/data/9827_2#49.bam
-56463236 + 0 in total (QC-passed reads + QC-failed reads)
-0 + 0 secondary
-0 + 0 supplementary
-269248 + 0 duplicates
-55357963 + 0 mapped (98.04% : N/A)
-56463236 + 0 paired in sequencing
-28231618 + 0 read1
-28231618 + 0 read2
-54363468 + 0 properly paired (96.28% : N/A)
-55062652 + 0 with itself and mate mapped
-295311 + 0 singletons (0.52% : N/A)
-360264 + 0 with mate mapped to a different chr
-300699 + 0 with mate mapped to a different chr (mapQ>=5)
-
-real    1m17.579s
-user    1m16.140s
-sys     0m1.310s
-
-$ time LD_PRELOAD=/tmp/zlib.intel/libz.so ./samtools flagstat ~/scratch/data/9827_2#49.bam
-56463236 + 0 in total (QC-passed reads + QC-failed reads)
-0 + 0 secondary
-0 + 0 supplementary
-269248 + 0 duplicates
-55357963 + 0 mapped (98.04% : N/A)
-56463236 + 0 paired in sequencing
-28231618 + 0 read1
-28231618 + 0 read2
-54363468 + 0 properly paired (96.28% : N/A)
-55062652 + 0 with itself and mate mapped
-295311 + 0 singletons (0.52% : N/A)
-360264 + 0 with mate mapped to a different chr
-300699 + 0 with mate mapped to a different chr (mapQ>=5)
-
-real    1m17.280s
-user    1m15.960s
-sys     0m1.200s
-{% endhighlight %}
-
-### CloudFlare ZLib
-
-{% highlight sh %}
-$ time LD_PRELOAD=/tmp/zlib.cloudflare/libz.so ./samtools flagstat ~/scratch/data/9827_2#49.bam
-56463236 + 0 in total (QC-passed reads + QC-failed reads)
-0 + 0 secondary
-0 + 0 supplementary
-269248 + 0 duplicates
-55357963 + 0 mapped (98.04% : N/A)
-56463236 + 0 paired in sequencing
-28231618 + 0 read1
-28231618 + 0 read2
-54363468 + 0 properly paired (96.28% : N/A)
-55062652 + 0 with itself and mate mapped
-295311 + 0 singletons (0.52% : N/A)
-360264 + 0 with mate mapped to a different chr
-300699 + 0 with mate mapped to a different chr (mapQ>=5)
-
-real    1m17.375s
-user    1m16.310s
-sys     0m0.940s
-
-$ time LD_PRELOAD=/tmp/zlib.cloudflare/libz.so ./samtools flagstat ~/scratch/data/9827_2#49.bam
-56463236 + 0 in total (QC-passed reads + QC-failed reads)
-0 + 0 secondary
-0 + 0 supplementary
-269248 + 0 duplicates
-55357963 + 0 mapped (98.04% : N/A)
-56463236 + 0 paired in sequencing
-28231618 + 0 read1
-28231618 + 0 read2
-54363468 + 0 properly paired (96.28% : N/A)
-55062652 + 0 with itself and mate mapped
-295311 + 0 singletons (0.52% : N/A)
-360264 + 0 with mate mapped to a different chr
-300699 + 0 with mate mapped to a different chr (mapQ>=5)
-
-real    1m17.144s
-user    1m16.020s
-sys     0m1.000s
-{% endhighlight %}
-
-Full read/write benchmarks
---------------------------
-
-### Original ZLib, default compression level
-
-{% highlight sh %}
-$ time ./samtools view -b -@ 4 -o /tmp/_.bam /nfs/users/nfs_j/jkb/scratch/data/9827_2#49.bam
-
-real    4m33.612s
-user    12m38.000s
-sys     0m19.920s
-
-$ ls -l /tmp/_.bam
--rw-r--r-- 1 jkb team117 6499959405 Apr 27 11:42 /tmp/_.bam
-
-$ time ./samtools view -b -@ 4 -o /tmp/_.bam /nfs/users/nfs_j/jkb/scratch/data/9827_2#49.bam
-
-real    4m31.879s
-user    12m29.380s
-sys     0m20.930s
-
-$ ls -l /tmp/_.bam
--rw-r--r-- 1 jkb team117 6499959405 Apr 27 11:53 /tmp/_.bam
-{% endhighlight %}
-
-### Intel ZLib, default compression level
-
-{% highlight sh %}
-$ time LD_PRELOAD=/tmp/zlib.intel/libz.so ./samtools view -b -@ 4 -o /tmp/_.bam /nfs/users/nfs_j/jkb/scratch/data/9827_2#49.bam
-
-real    3m49.306s
-user    9m36.150s
-sys     0m21.290s
-$ ls -l /tmp/_.bam
--rw-r--r-- 1 jkb team117 6580893700 Apr 27 11:45 /tmp/_.bam
-
-$ time LD_PRELOAD=/tmp/zlib.intel/libz.so ./samtools view -b -@ 4 -o /tmp/_.bam /nfs/users/nfs_j/jkb/scratch/data/9827_2#49.bam
-
-real    3m52.742s
-user    9m43.360s
-sys     0m20.590s
-$ ls -l /tmp/_.bam
--rw-r--r-- 1 jkb team117 6580893700 Apr 27 11:57 /tmp/_.bam
-{% endhighlight %}
-
-### CloudFlare ZLib, default compression level
-
-{% highlight sh %}
-$ time LD_PRELOAD=/tmp/zlib.cloudflare/libz.so ./samtools view -b -@ 4 -o /tmp/_.bam /nfs/users/nfs_j/jkb/scratch/data/9827_2#49.bam
-
-real    3m23.885s
-user    7m51.620s
-sys     0m21.210s
-
-$ ls -l /tmp/_.bam
--rw-r--r-- 1 jkb team117 6445044187 Apr 27 11:49 /tmp/_.bam
-
-$ time LD_PRELOAD=/tmp/zlib.cloudflare/libz.so ./samtools view -b -@ 4 -o /tmp/_.bam /nfs/users/nfs_j/jkb/scratch/data/9827_2#49.bam
-
-real    3m24.938s
-user    7m55.610s
-sys     0m21.430s
-
-$ ls -l /tmp/_.bam
--rw-r--r-- 1 jkb team117 6445044187 Apr 27 12:01 /tmp/_.bam
-{% endhighlight %}
-
-### Original ZLib, lowest compression level
-
-{% highlight sh %}
-$ time ./samtools view -1 -b -@ 4 -o /tmp/_.bam /nfs/users/nfs_j/jkb/scratch/data/9827_2#49.bam
-
-real    2m59.867s
-user    6m21.680s
-sys     0m20.210s
-
-$ ls -l /tmp/_.bam
--rw-r--r-- 1 jkb team117 7042519949 Apr 27 11:23 /tmp/_.bam
-
-$ time ./samtools view -1 -b -@ 4 -o /tmp/_.bam /nfs/users/nfs_j/jkb/scratch/data/9827_2#49.bam
-
-real    3m1.529s
-user    6m21.060s
-sys     0m22.180s
-
-$ ls -l /tmp/_.bam
--rw-r--r-- 1 jkb team117 7042519949 Apr 27 11:32 /tmp/_.bam
-{% endhighlight %}
-
-### Intel ZLib, lowest compression level
-
-{% highlight sh %}
-$ time LD_PRELOAD=/tmp/zlib.intel/libz.so ./samtools view -1 -b -@ 4 -o /tmp/_.bam /nfs/users/nfs_j/jkb/scratch/data/9827_2#49.bam
-
-real    2m24.214s
-user    4m0.170s
-sys     0m14.790s
-
-$ ls -l /tmp/_.bam
--rw-r--r-- 1 jkb team117 9019497823 Apr 27 11:26 /tmp/_.bam
-
-$ time LD_PRELOAD=/tmp/zlib.intel/libz.so ./samtools view -1 -b -@ 4 -o /tmp/_.bam /nfs/users/nfs_j/jkb/scratch/data/9827_2#49.bam
-
-real    2m25.409s
-user    4m2.690s
-sys     0m13.300s
-
-$ ls -l /tmp/_.bam
--rw-r--r-- 1 jkb team117 9019497823 Apr 27 11:34 /tmp/_.bam
-{% endhighlight %}
-
-### CloudFlare ZLib, lowest compression level
-
-{% highlight sh %}
-$ time LD_PRELOAD=/tmp/zlib.cloudflare/libz.so ./samtools view -1 -b -@ 4 -o /tmp/_.bam /nfs/users/nfs_j/jkb/scratch/data/9827_2#49.bam
-
-real    2m52.685s
-user    5m39.080s
-sys     0m23.250s
-
-$ ls -l /tmp/_.bam
--rw-r--r-- 1 jkb team117 6816769584 Apr 27 11:29 /tmp/_.bam
-
-$ time LD_PRELOAD=/tmp/zlib.cloudflare/libz.so ./samtools view -1 -b -@ 4 -o /tmp/_.bam /nfs/users/nfs_j/jkb/scratch/data/9827_2#49.bam
-
-real    2m54.839s
-user    5m44.820s
-sys     0m23.270s
-
-$ ls -l /tmp/_.bam
--rw-r--r-- 1 jkb team117 6816769584 Apr 27 11:37 /tmp/_.bam
-{% endhighlight %}
-
-### Intel igzip library, lowest compresion level
-
-{% highlight sh %}
-$ time ./test/test_view -@ 4 -l 1 -b ~/scratch/data/9827_2#49.bam > /tmp/_.bam;ls -l /tmp/_.bam
-
-real    2m9.550s
-user    3m17.260s
-sys     0m9.190s
--rw-r--r-- 1 jkb team117 7324800394 Apr 28 14:54 /tmp/_.bam
-
-$ time ./test/test_view -@ 4 -l 1 -b ~/scratch/data/9827_2#49.bam > /tmp/_.bam;ls -l /tmp/_.bam
-
-real    2m14.863s
-user    3m17.730s
-sys     0m7.990s
--rw-r--r-- 1 jkb team117 7324800394 Apr 28 14:59 /tmp/_.bam
-{% endhighlight %}
+All implementations fair favourably compared to the vanilla zlib
+implementation.
+
+Libdeflate is our recommended library as can be seen above.  It offers
+a considerable speed improvement for both decoding and encoding. File
+sizes are a bit larger than the default zlib, although for
+(considerably) more CPU time it scales up to level 12 compared the
+default level 9 which offers the best size (not shown here).
+
+CloudFlare's zlib offers a good default file size for not much more
+time than libdeflate so is still a worthy contender.
+
+The Intel zlib specialises in fast compression at level -1, albeit
+at a weaker compression ratio.  The BAM-specific mode of igzip takes
+this further offering the best speeds, but file sizes are still behind
+most other implementations.  It has potential use for intermediate
+temporary files, like likely something completely different such as
+LZ4 would be preferable.
+
+Both Intel and CloudFlare Zlib's can be used with LD_PRELOAD or
+LD_LIBRARY_PATH without needing to recompile samtools/htslib, provided
+it was built without enabling --with-libdeflate.


### PR DESCRIPTION
Zlib:  I reran the tests (bar the igzip one which required code changes) to include libdeflate.

CRAM: lots has changed since last done.   I've culled some of the tedious details and added new tedium instead. :-)

I also included the effect of the proposed new CRAM 3.1 standard as well as the effect of the minhash sorting.  Neither of these are in current samtools, but the document makes sense as an indication of where things are headed even without these being released.

Ideally I'd do some charts to avoid walls of tables, but currently don't have the time.

Previews at:

http://jkbonfield.github.io/www.htslib.org/benchmarks/zlib.html
http://jkbonfield.github.io/www.htslib.org/benchmarks/CRAM.html