### PR TITLE
Fix the formatting of the samtools mpileup man page

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
+.jekyll-cache
 _site

--- a/doc/samtools-coverage.html
+++ b/doc/samtools-coverage.html
@@ -23,15 +23,15 @@ histogram or tabulated text.
 The tabulated form uses the following headings.
 <p>
 <table>
-<tr><td>rname</td><td>Reference name / chromosome</td></tr>
-<tr><td>startpos</td><td>Start position</td></tr>
-<tr><td>endpos</td><td>End position (or sequence length)</td></tr>
-<tr><td>numreads</td><td>Number reads aligned to the region (after filtering)</td></tr>
-<tr><td>covbases</td><td>Number of covered bases with depth >= 1</td></tr>
-<tr><td>coverage</td><td>Proportion of covered bases [0..1]</td></tr>
-<tr><td>meandepth</td><td>Mean depth of coverage</td></tr>
-<tr><td>meanbaseq</td><td>Mean baseQ in covered region</td></tr>
-<tr><td>meanmapq</td><td>Mean mapQ of selected reads</td></tr>
+<tr><td><b>rname</b></td><td>Reference name / chromosome</td></tr>
+<tr><td><b>startpos</b></td><td>Start position</td></tr>
+<tr><td><b>endpos</b></td><td>End position (or sequence length)</td></tr>
+<tr><td><b>numreads</b></td><td>Number reads aligned to the region (after filtering)</td></tr>
+<tr><td><b>covbases</b></td><td>Number of covered bases with depth &gt;= 1</td></tr>
+<tr><td><b>coverage</b></td><td>Proportion of covered bases [0..1]</td></tr>
+<tr><td><b>meandepth</b></td><td>Mean depth of coverage</td></tr>
+<tr><td><b>meanbaseq</b></td><td>Mean baseQ in covered region</td></tr>
+<tr><td><b>meanmapq</b></td><td>Mean mapQ of selected reads</td></tr>
 </table>
 <p>
 <h1 id="OPTIONS"><a href="#OPTIONS">OPTIONS</a></h1>

--- a/doc/samtools-flags.html
+++ b/doc/samtools-flags.html
@@ -20,18 +20,18 @@ Convert between textual and numeric flag representation.
 <p>
 <b>FLAGS:</b>
 <table>
-<tr><td>0x1</td><td>PAIRED</td><td>paired-end (or multiple-segment) sequencing technology</td></tr>
-<tr><td>0x2</td><td>PROPER_PAIR</td><td>each segment properly aligned according to the aligner</td></tr>
-<tr><td>0x4</td><td>UNMAP</td><td>segment unmapped</td></tr>
-<tr><td>0x8</td><td>MUNMAP</td><td>next segment in the template unmapped</td></tr>
-<tr><td>0x10</td><td>REVERSE</td><td>SEQ is reverse complemented</td></tr>
-<tr><td>0x20</td><td>MREVERSE</td><td>SEQ of the next segment in the template is reverse complemented</td></tr>
-<tr><td>0x40</td><td>READ1</td><td>the first segment in the template</td></tr>
-<tr><td>0x80</td><td>READ2</td><td>the last segment in the template</td></tr>
-<tr><td>0x100</td><td>SECONDARY</td><td>secondary alignment</td></tr>
-<tr><td>0x200</td><td>QCFAIL</td><td>not passing quality controls</td></tr>
-<tr><td>0x400</td><td>DUP</td><td>PCR or optical duplicate</td></tr>
-<tr><td>0x800</td><td>SUPPLEMENTARY</td><td>supplementary alignment</td></tr>
+<tr><td><b>0x1</b></td><td>PAIRED</td><td>paired-end (or multiple-segment) sequencing technology</td></tr>
+<tr><td><b>0x2</b></td><td>PROPER_PAIR</td><td>each segment properly aligned according to the aligner</td></tr>
+<tr><td><b>0x4</b></td><td>UNMAP</td><td>segment unmapped</td></tr>
+<tr><td><b>0x8</b></td><td>MUNMAP</td><td>next segment in the template unmapped</td></tr>
+<tr><td><b>0x10</b></td><td>REVERSE</td><td>SEQ is reverse complemented</td></tr>
+<tr><td><b>0x20</b></td><td>MREVERSE</td><td>SEQ of the next segment in the template is reverse complemented</td></tr>
+<tr><td><b>0x40</b></td><td>READ1</td><td>the first segment in the template</td></tr>
+<tr><td><b>0x80</b></td><td>READ2</td><td>the last segment in the template</td></tr>
+<tr><td><b>0x100</b></td><td>SECONDARY</td><td>secondary alignment</td></tr>
+<tr><td><b>0x200</b></td><td>QCFAIL</td><td>not passing quality controls</td></tr>
+<tr><td><b>0x400</b></td><td>DUP</td><td>PCR or optical duplicate</td></tr>
+<tr><td><b>0x800</b></td><td>SUPPLEMENTARY</td><td>supplementary alignment</td></tr>
 </table>
 <p>
 <h1 id="AUTHOR"><a href="#AUTHOR">AUTHOR</a></h1>

--- a/doc/samtools-mpileup.html
+++ b/doc/samtools-mpileup.html
@@ -64,20 +64,18 @@ taking its ASCII value and subtracting 33; e.g., &ldquo;A&rdquo; encodes the
 numeric value 32.
 <p>
 The first three columns give the position and reference:
-<p>
-Chromosome name.
-<p>
-1-based position on the chromosome.
-<p>
-Reference base at this position (this will be &ldquo;N&rdquo; on all lines
+<ul><li>Chromosome name.
+</li>
+<li>1-based position on the chromosome.
+</li>
+<li>Reference base at this position (this will be &ldquo;N&rdquo; on all lines
 if <b>-f</b>/<b>--fasta-ref</b> has not been used).
-<p>
+</li></ul><p>
 The remaining columns show the pileup data, and are repeated for each
 input BAM file specified:
-<p>
-Number of reads covering this position.
-<p>
-Read bases.
+<ul><li>Number of reads covering this position.
+</li>
+<li>Read bases.
 This encodes information on matches, mismatches, indels, strand,
 mapping quality, and starts and ends of reads.
 <p>
@@ -89,10 +87,10 @@ followed by the alignment's mapping quality encoded as an ASCII character.
 has been mapped:
 <table>
 <tr><th>Forward</th><th>Reverse</th><th>Meaning</th></tr>
-<tr><th>\&.\fR dot</th><th>,\fR comma</th><th>Base matches the reference base</th></tr>
-<tr><td>ACGTN</td><td>acgtn</td><td>Base is a mismatch to the reference base</td></tr>
-<tr><td>></td><td><</td><td>Reference skip (due to CIGAR \(lqN\(rq)</td></tr>
-<tr><td>*</td><td>*\fR/\fB#</td><td>Deletion of the reference base (CIGAR \(lqD\(rq)</td></tr>
+<tr><td><b>.</b> dot</td><td><b>,</b> comma</td><td>Base matches the reference base</td></tr>
+<tr><td><b>ACGTN</b></td><td><b>acgtn</b></td><td>Base is a mismatch to the reference base</td></tr>
+<tr><td><b>&gt;</b></td><td><b>&lt;</b></td><td>Reference skip (due to CIGAR &ldquo;N&rdquo;)</td></tr>
+<tr><td><b>*</b></td><td><b>*</b>/<b>#</b></td><td>Deletion of the reference base (CIGAR &ldquo;D&rdquo;)</td></tr>
 </table>
 <p>
 Deleted bases are shown as &ldquo;*&rdquo; on both strands
@@ -111,24 +109,26 @@ reference bases represented similarly.  (Subsequent pileup lines will
 contain &ldquo;*&rdquo; for this read indicating the deleted bases.)
 </li>
 <li>If this is the last position covered by the read, a &ldquo;$&rdquo; character.
-<p>
-Base qualities, encoded as ASCII characters.
-<p>
-Alignment mapping qualities, encoded as ASCII characters.
+</li></ul>
+</li>
+<li>Base qualities, encoded as ASCII characters.
+</li>
+<li>Alignment mapping qualities, encoded as ASCII characters.
 (Column only present when <b>-s</b>/<b>--output-MQ</b> is used.)
-<p>
-Comma-separated 1-based positions within the alignments, e.g., 5 indicates
+</li>
+<li>Comma-separated 1-based positions within the alignments, e.g., 5 indicates
 that it is the fifth base of the corresponding read that is mapped to this
 genomic position.
 (Column only present when <b>-O</b>/<b>--output-BP</b> is used.)
-<p>
-Comma-separated read names.
+</li>
+<li>Comma-separated read names.
 (Column only present when <b>--output-QNAME</b> is used.)
-<p>
-Additional columns containing other specified read fields or tags,
+</li>
+<li>Additional columns containing other specified read fields or tags,
 as selected via the <b>--output-extra</b>, <b>--output-sep</b>,
 and <b>--output-empty</b> options.
 <p>
+</li></ul>
 <h1 id="OPTIONS"><a href="#OPTIONS">OPTIONS</a></h1>
 <dl><dt><b>-6, --illumina1.3+</b></dt><dd><p>
 Assume the quality is in the Illumina 1.3+ encoding.
@@ -367,7 +367,7 @@ The
 <b>calmd</b>
 command is used to reduce false heterozygotes around INDELs.
 <p>
-</ul>
+</li></ul>
 <h1 id="AUTHOR"><a href="#AUTHOR">AUTHOR</a></h1>
 <p>
 Written by Heng Li from the Sanger Institute.

--- a/doc/samtools-split.html
+++ b/doc/samtools-split.html
@@ -44,11 +44,11 @@ Do not add a @PG line to the header of the output file.
 </dd></dl><p>
 Format string expansions:
 <table align="center">
-<tr><td>%%</td><td>%</td></tr>
-<tr><td>%*</td><td>basename</td></tr>
-<tr><td>%#</td><td>@RG index</td></tr>
-<tr><td>%!</td><td>@RG ID</td></tr>
-<tr><td>%.</td><td>output format filename extension</td></tr>
+<tr><td><b>%%</b></td><td>%</td></tr>
+<tr><td><b>%*</b></td><td>basename</td></tr>
+<tr><td><b>%#</b></td><td>@RG index</td></tr>
+<tr><td><b>%!</b></td><td>@RG ID</td></tr>
+<tr><td><b>%.</b></td><td>output format filename extension</td></tr>
 </table>
 <dl><dt><b>-@, --threads </b><em>INT</em></dt><dd><p>
 Number of input/output compression threads to use in addition to main thread [0].

--- a/doc/samtools-stats.html
+++ b/doc/samtools-stats.html
@@ -25,33 +25,33 @@ A summary of output sections is listed below, followed by more
 detailed descriptions.
 <p>
 <table>
-<tr><td>CHK     Checksum</td></tr>
-<tr><td>SN      Summary numbers</td></tr>
-<tr><td>FFQ     First fragment qualities</td></tr>
-<tr><td>LFQ     Last fragment qualities</td></tr>
-<tr><td>GCF     GC content of first fragments</td></tr>
-<tr><td>GCL     GC content of last fragments</td></tr>
-<tr><td>GCC     ACGT content per cycle</td></tr>
-<tr><td>FBC     ACGT content per cycle for first fragments only</td></tr>
-<tr><td>FTC     ACGT raw counters for first fragments</td></tr>
-<tr><td>LBC     ACGT content per cycle for last fragments only</td></tr>
-<tr><td>LTC     ACGT raw counters for last fragments</td></tr>
-<tr><td>BCC     ACGT content per cycle for BC barcode</td></tr>
-<tr><td>CRC     ACGT content per cycle for CR barcode</td></tr>
-<tr><td>OXC     ACGT content per cycle for OX barcode</td></tr>
-<tr><td>RXC     ACGT content per cycle for RX barcode</td></tr>
-<tr><td>QTQ     Quality distribution for BC barcode</td></tr>
-<tr><td>CYQ     Quality distribution for CR barcode</td></tr>
-<tr><td>BZQ     Quality distribution for OX barcode</td></tr>
-<tr><td>QXQ     Quality distribution for RX barcode</td></tr>
-<tr><td>IS      Insert sizes</td></tr>
-<tr><td>RL      Read lengths</td></tr>
-<tr><td>FRL     Read lengths for first fragments only</td></tr>
-<tr><td>LRL     Read lengths for last fragments only</td></tr>
-<tr><td>ID      Indel size distribution</td></tr>
-<tr><td>IC      Indels per cycle</td></tr>
-<tr><td>COV     Coverage (depth) distribution</td></tr>
-<tr><td>GCD     GC-depth</td></tr>
+<tr><td><b>CHK</b></td><td>Checksum</td></tr>
+<tr><td><b>SN</b></td><td>Summary numbers</td></tr>
+<tr><td><b>FFQ</b></td><td>First fragment qualities</td></tr>
+<tr><td><b>LFQ</b></td><td>Last fragment qualities</td></tr>
+<tr><td><b>GCF</b></td><td>GC content of first fragments</td></tr>
+<tr><td><b>GCL</b></td><td>GC content of last fragments</td></tr>
+<tr><td><b>GCC</b></td><td>ACGT content per cycle</td></tr>
+<tr><td><b>FBC</b></td><td>ACGT content per cycle for first fragments only</td></tr>
+<tr><td><b>FTC</b></td><td>ACGT raw counters for first fragments</td></tr>
+<tr><td><b>LBC</b></td><td>ACGT content per cycle for last fragments only</td></tr>
+<tr><td><b>LTC</b></td><td>ACGT raw counters for last fragments</td></tr>
+<tr><td><b>BCC</b></td><td>ACGT content per cycle for BC barcode</td></tr>
+<tr><td><b>CRC</b></td><td>ACGT content per cycle for CR barcode</td></tr>
+<tr><td><b>OXC</b></td><td>ACGT content per cycle for OX barcode</td></tr>
+<tr><td><b>RXC</b></td><td>ACGT content per cycle for RX barcode</td></tr>
+<tr><td><b>QTQ</b></td><td>Quality distribution for BC barcode</td></tr>
+<tr><td><b>CYQ</b></td><td>Quality distribution for CR barcode</td></tr>
+<tr><td><b>BZQ</b></td><td>Quality distribution for OX barcode</td></tr>
+<tr><td><b>QXQ</b></td><td>Quality distribution for RX barcode</td></tr>
+<tr><td><b>IS</b></td><td>Insert sizes</td></tr>
+<tr><td><b>RL</b></td><td>Read lengths</td></tr>
+<tr><td><b>FRL</b></td><td>Read lengths for first fragments only</td></tr>
+<tr><td><b>LRL</b></td><td>Read lengths for last fragments only</td></tr>
+<tr><td><b>ID</b></td><td>Indel size distribution</td></tr>
+<tr><td><b>IC</b></td><td>Indels per cycle</td></tr>
+<tr><td><b>COV</b></td><td>Coverage (depth) distribution</td></tr>
+<tr><td><b>GCD</b></td><td>GC-depth</td></tr>
 </table>
 <p>
 Not all sections will be reported as some depend on the data being
@@ -74,7 +74,7 @@ fragments.
 </li>
 <li>Reads where PAIRED is set and either both READ1 and READ2 are set or
 neither is set are not counted in either category.
-</ul><p>
+</li></ul><p>
 The CHK row contains distinct CRC32 checksums of read names, sequences
 and quality values.  The checksums are computed per alignment record
 and summed, meaning the checksum does not change if the input file has

--- a/doc/samtools.html
+++ b/doc/samtools.html
@@ -85,9 +85,9 @@ entire alignment file unless it is asked to do so.
 <h1 id="COMMANDS"><a href="#COMMANDS">COMMANDS</a></h1>
 <p>
 Each command has its own man page which can be viewed using
-e.g. <b>man samtools-view</b> or with a recent GNU man using \fBman
-samtools view\fR.  Below we have a brief summary of syntax and
-sub-command description.
+e.g. <b>man samtools-view</b> or with a recent GNU man using
+<b>man samtools view</b>.  Below we have a brief summary of syntax
+and sub-command description.
 <p>
 Options common to all sub-commands are documented below in the GLOBAL
 COMMAND OPTIONS section.
@@ -410,18 +410,18 @@ Convert between textual and numeric flag representation.
 <p>
 <b>FLAGS:</b>
 <table>
-<tr><td>0x1</td><td>PAIRED</td><td>paired-end (or multiple-segment) sequencing technology</td></tr>
-<tr><td>0x2</td><td>PROPER_PAIR</td><td>each segment properly aligned according to the aligner</td></tr>
-<tr><td>0x4</td><td>UNMAP</td><td>segment unmapped</td></tr>
-<tr><td>0x8</td><td>MUNMAP</td><td>next segment in the template unmapped</td></tr>
-<tr><td>0x10</td><td>REVERSE</td><td>SEQ is reverse complemented</td></tr>
-<tr><td>0x20</td><td>MREVERSE</td><td>SEQ of the next segment in the template is reverse complemented</td></tr>
-<tr><td>0x40</td><td>READ1</td><td>the first segment in the template</td></tr>
-<tr><td>0x80</td><td>READ2</td><td>the last segment in the template</td></tr>
-<tr><td>0x100</td><td>SECONDARY</td><td>secondary alignment</td></tr>
-<tr><td>0x200</td><td>QCFAIL</td><td>not passing quality controls</td></tr>
-<tr><td>0x400</td><td>DUP</td><td>PCR or optical duplicate</td></tr>
-<tr><td>0x800</td><td>SUPPLEMENTARY</td><td>supplementary alignment</td></tr>
+<tr><td><b>0x1</b></td><td>PAIRED</td><td>paired-end (or multiple-segment) sequencing technology</td></tr>
+<tr><td><b>0x2</b></td><td>PROPER_PAIR</td><td>each segment properly aligned according to the aligner</td></tr>
+<tr><td><b>0x4</b></td><td>UNMAP</td><td>segment unmapped</td></tr>
+<tr><td><b>0x8</b></td><td>MUNMAP</td><td>next segment in the template unmapped</td></tr>
+<tr><td><b>0x10</b></td><td>REVERSE</td><td>SEQ is reverse complemented</td></tr>
+<tr><td><b>0x20</b></td><td>MREVERSE</td><td>SEQ of the next segment in the template is reverse complemented</td></tr>
+<tr><td><b>0x40</b></td><td>READ1</td><td>the first segment in the template</td></tr>
+<tr><td><b>0x80</b></td><td>READ2</td><td>the last segment in the template</td></tr>
+<tr><td><b>0x100</b></td><td>SECONDARY</td><td>secondary alignment</td></tr>
+<tr><td><b>0x200</b></td><td>QCFAIL</td><td>not passing quality controls</td></tr>
+<tr><td><b>0x400</b></td><td>DUP</td><td>PCR or optical duplicate</td></tr>
+<tr><td><b>0x800</b></td><td>SUPPLEMENTARY</td><td>supplementary alignment</td></tr>
 </table>
 <p>
 </dd><dt><b>fastq/a</b></dt><dd><p>
@@ -673,19 +673,19 @@ By default all fields are used.  Limiting the decode to specific
 columns can have significant performance gains.  The bit-field is a
 numerical value constructed from the following table.
 <table>
-<tr><td>0x1</td><td>SAM_QNAME</td></tr>
-<tr><td>0x2</td><td>SAM_FLAG</td></tr>
-<tr><td>0x4</td><td>SAM_RNAME</td></tr>
-<tr><td>0x8</td><td>SAM_POS</td></tr>
-<tr><td>0x10</td><td>SAM_MAPQ</td></tr>
-<tr><td>0x20</td><td>SAM_CIGAR</td></tr>
-<tr><td>0x40</td><td>SAM_RNEXT</td></tr>
-<tr><td>0x80</td><td>SAM_PNEXT</td></tr>
-<tr><td>0x100</td><td>SAM_TLEN</td></tr>
-<tr><td>0x200</td><td>SAM_SEQ</td></tr>
-<tr><td>0x400</td><td>SAM_QUAL</td></tr>
-<tr><td>0x800</td><td>SAM_AUX</td></tr>
-<tr><td>0x1000</td><td>SAM_RGAUX</td></tr>
+<tr><td><b>0x1</b></td><td>SAM_QNAME</td></tr>
+<tr><td><b>0x2</b></td><td>SAM_FLAG</td></tr>
+<tr><td><b>0x4</b></td><td>SAM_RNAME</td></tr>
+<tr><td><b>0x8</b></td><td>SAM_POS</td></tr>
+<tr><td><b>0x10</b></td><td>SAM_MAPQ</td></tr>
+<tr><td><b>0x20</b></td><td>SAM_CIGAR</td></tr>
+<tr><td><b>0x40</b></td><td>SAM_RNEXT</td></tr>
+<tr><td><b>0x80</b></td><td>SAM_PNEXT</td></tr>
+<tr><td><b>0x100</b></td><td>SAM_TLEN</td></tr>
+<tr><td><b>0x200</b></td><td>SAM_SEQ</td></tr>
+<tr><td><b>0x400</b></td><td>SAM_QUAL</td></tr>
+<tr><td><b>0x800</b></td><td>SAM_AUX</td></tr>
+<tr><td><b>0x1000</b></td><td>SAM_RGAUX</td></tr>
 </table>
 </dd><dt><b>name_prefix=</b><em>string</em></dt><dd><p>
 CRAM input only; defaults to output filename.  Any sequences with
@@ -744,7 +744,7 @@ For example: to convert a BAM to a compressed SAM with CSI indexing:
 samtools view -h -O sam,level=6 --write-index in.bam -o out.sam.gz
 </pre>
 <p>
-The <b>--verbosity \fIINT</b> option sets the verbosity level for samtools
+The <b>--verbosity </b><em>INT</em> option sets the verbosity level for samtools
 and HTSlib.  The default is 3 (HTS_LOG_WARNING); 2 reduces warning messages
 and 0 or 1 also reduces some error messages, while values greater than 3
 produce increasing numbers of additional warnings and logging messages.
@@ -851,12 +851,12 @@ command.
 samtools view -C -T ref.fa aln.bam &gt; aln.cram
 </pre>
 <p>
-</ul>
+</li></ul>
 <h1 id="LIMITATIONS"><a href="#LIMITATIONS">LIMITATIONS</a></h1>
 <p>
 <ul><li>Unaligned words used in bam_endian.h, bam.c and bam_aux.c.
 <p>
-</ul>
+</li></ul>
 <h1 id="AUTHOR"><a href="#AUTHOR">AUTHOR</a></h1>
 <p>
 Heng Li from the Sanger Institute wrote the original C version of


### PR DESCRIPTION
Fix the formatting of the nested `<ul>` lists and tables in the [samtools mpileup](https://www.htslib.org/doc/samtools-mpileup.html) manual page.

Fixed by regenerating with an updated `man2fhtml` that recognises `.IP \(ci` as an itemised list, handles nested `<ul>` lists, and interprets table column formatting directives and font escapes within table cells.

Also updated a few other web pages that benefit from the table column formatting improvements. Applied PR samtools/samtools#1224 first, so that this web page update cherry-picks those formatting improvements as well.

Also ignore Jekyll 4.0's new .jekyll-cache directory.