### PR TITLE
Fix manpage style sheet: Clear after DT/DD for H1/H2 as well as P

### DIFF
--- a/css/manpage.css
+++ b/css/manpage.css
@@ -1,9 +1,10 @@
 .release { float: right; text-align: right; color: gray; font-size: 90% }
-.manpage p { clear: both; }
+
 .manpage dl { clear: both; margin-left: 8em; }
+.manpage dl::after { content: ""; display: block; clear: both; }
 .manpage dt { float: left; clear: both; min-width: 8em; margin-left: -8em;
               font-weight: normal; }
-.manpage dd { /* padding-left: 7em; */ float: left; width: 100%; clear: right; }
+.manpage dd { float: left; width: 100%; clear: right; }
 
 .manpage table { border-collapse: collapse }
 .manpage th { padding-right: 2em }


### PR DESCRIPTION
Not all `.SH`/`.SS` headings are preceded by `.PP`/etc, so we need to ensure the resulting `<H1>`/`<H2>` clears the resulting floats too. This makes a difference with Safari, where previously the heading appeared off to the right of the page alongside the previous `.TP` list, e.g. for [_tabix.html_](http://www.htslib.org/doc/tabix.html):

![Screenshot 2022-04-11 at 11 41 12](https://user-images.githubusercontent.com/70921/162740120-5fa0e8bf-2588-4e70-90f7-bef1049c2a65.png)