### PR TITLE
Remove mailing list documentation and mention BioStars

### DIFF
--- a/_includes/header.html
+++ b/_includes/header.html
@@ -57,10 +57,10 @@
 							Support <span class="caret"></span>
 						</a>
 						<ul class="dropdown-menu" role="menu">
-							<li><a href="{{ "/support#mailing-lists" | relative_url }}">Mailing Lists</a></li>
-				            <li><a href="https://github.com/samtools/htslib/issues">HTSlib issues</a></li>
-				            <li><a href="https://github.com/samtools/bcftools/issues">BCFtools issues</a></li>
-				            <li><a href="https://github.com/samtools/samtools/issues">Samtools issues</a></li>
+							<li><a href="https://github.com/samtools/htslib/issues">HTSlib issues</a></li>
+							<li><a href="https://github.com/samtools/bcftools/issues">BCFtools issues</a></li>
+							<li><a href="https://github.com/samtools/samtools/issues">Samtools issues</a></li>
+							<li><a href="{{ "/support#general-help" | relative_url }}">General help</a></li>
 						</ul>
 					</li>
 				</ul>

--- a/index.html
+++ b/index.html
@@ -64,10 +64,10 @@ layout: default
 		<div class="well">
 			<h3><a href="{{ "/support" | relative_url }}"><i class="glyphicon glyphicon-question-sign"></i> Support</a></h3>
 			<ul>
-				<li><a href="{{ "/support#lists" | relative_url }}">Mailing Lists</a></li>
 				<li><a href="https://github.com/samtools/htslib/issues">HTSlib issues</a></li>
 				<li><a href="https://github.com/samtools/bcftools/issues">BCFtools issues</a></li>
 				<li><a href="https://github.com/samtools/samtools/issues">Samtools issues</a></li>
+				<li><a href="{{ "/support#general-help" | relative_url }}">General help</a></li>
 			</ul>
 		</div>
 	</div>

--- a/support.md
+++ b/support.md
@@ -12,22 +12,11 @@ If you have found a bug or would like a new feature, please open a new issue on 
 * [SAMtools](https://github.com/samtools/samtools/issues) issue tracker
 
 
-# Mailing Lists
+# General help
 
-### SAMtools Announce
-New SAMtools suite releases and critical bug fixes will be announced to this list. This list is low traffic.
-
-[https://lists.sourceforge.net/lists/listinfo/samtools-announce](https://lists.sourceforge.net/lists/listinfo/samtools-announce)
-
-### SAMtools Help
-Help on how to use SAMtools, BCFtools and HTSlib.
-Bug reports and feature requests can also be files here if you do not want to use GitHub.
-Note that you need to be subscribed to the list in order to post to it.
-
-[https://lists.sourceforge.net/lists/listinfo/samtools-help](https://lists.sourceforge.net/lists/listinfo/samtools-help)
-
-### SAMtools Devel
-Discussion on development.
-Note that you need to be subscribed to the list in order to post to it.
-
-[https://lists.sourceforge.net/lists/listinfo/samtools-devel](https://lists.sourceforge.net/lists/listinfo/samtools-devel)
+For general queries we recommend posting to [Biostars](https://www.biostars.org)
+or [Bioinformatics Stack Exchange](https://bioinformatics.stackexchange.com/)
+as these will reach a much larger audience and generally receive a faster
+response time than GitHub.  Note, if you do post to both GitHub and an external
+site, please do mention this so we can see if the problem has been resolved
+already.


### PR DESCRIPTION
The SourceForge mailing lists are just a pitfall for novice bioinformaticians.  There is minimal readership now.  Biostars has taken on this mantle and has a big readership of knowledgeable people.

We already explicitly stated that issues are meant to be for bug reports and feature requests, which raises the question of what to do about everything else.  While we can field some queries, it's best for the community to help each other and this is already being actively well done elsewhere.